### PR TITLE
🚀 Release v0.0.4: 카드 이미지에 정적 파일 제공 기능 추가 (feature/#8 -> main)

### DIFF
--- a/app/data/models/learning_models.py
+++ b/app/data/models/learning_models.py
@@ -32,7 +32,25 @@ class LessonProgress(BaseModel):
     stage3_completed: bool = Field(default=False, description="3단계 완료 여부")
     progress_rate: int = Field(default=0, description="전체 진행도 (25% 단위)")
     last_updated: datetime = Field(default_factory=datetime.now, description="마지막 업데이트 시간")
-    completed_at: Optional[datetime] = Field(None, description="학습 완료 시간")
+
+class LessonData(BaseModel):
+    """차시 기본 정보"""
+    lesson_id: str = Field(..., description="차시 ID")
+    chapter_id: str = Field(..., description="단원 ID")
+    title: str = Field(..., description="차시 제목")
+    description: str = Field(..., description="차시 설명")
+    word_count: int = Field(..., description="학습할 단어 쌍 수")
+
+class LessonResponse(BaseModel):
+    """차시 정보 응답"""
+    lesson_id: str = Field(..., description="차시 ID")
+    chapter_id: str = Field(..., description="단원 ID")
+    title: str = Field(..., description="차시 제목")
+    description: str = Field(..., description="차시 설명")
+    is_locked: bool = Field(..., description="잠금 여부")
+    progress: LessonProgress = Field(..., description="진행도")
+    word_pairs: List[Dict[str, str]] = Field(..., description="학습할 단어 쌍 목록")
+
 
 class WordCard(BaseModel):
     """어휘 학습 카드 모델"""

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 import logging
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
 from app.api.chat.chat_router import router as chat_router
 from app.api.system.indexing import router as indexing_router
 from app.api.learning.learning_router import router as learning_router
@@ -32,6 +33,9 @@ app = FastAPI(
         },
     ]
 )
+
+# Static 파일 마운트 (이미지 파일 서빙을 위해)
+app.mount("/images", StaticFiles(directory="app/static/images"), name="images")
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## 🚀 해당 PR 은 main 브랜치로의 Release PR 입니다.

### 🚨 Releas check list 🚨

```
- commit message가 적절한지 확인해주세요. 
- Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
```

---

## 🧑🏻‍💻 PR 요약
- 학습 단계 UI 에서 카드 이미지를 로드할 때 발생하는 404 오류를 해결하기 위해 FastAPI 정적 파일 제공 구성을 추가
- `app/main.py` 에 StaticFiles 가져오기 추가
- `app/static/images` 디렉토리의 정적 파일을 제공하기 위해 /images 엔드포인트 마운트
- 모든 카드 이미지 (앞면/뒷면 변형)에 대한 이미지 로딩 문제 해결
- 카드이미지를 로드하려고 할 때 프론트에서 404 오류 해결

---

## 😁 관련 이슈
- #8